### PR TITLE
Feat/fee whitelist

### DIFF
--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -31,9 +31,11 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
 
     // IMPORTANT : will not apply fee if the caller is the dsSwapContract
     // WARNING : not applying fee also comes with disabling rounding error safeguard check as it creates an inexact amount of tokens needed for repayment
-    // maybe will be added back at later date if we decided to have a fee on DS swap
-    function feeWhitelisted()  internal view returns (bool) {
-        return msg.sender == dsSwapContract;
+    // maybe will be added back at later date if we decided to have a fee on DS swap.
+    // potential result of this is on every trade, there's a possibility that the actual repayment amount transferred is verrrry slightly less than the amount needed for repayment. 
+    // leaving the AMM with verry slightly less liquidity from before
+    function applyFee()  internal view returns (bool) {
+        return !(msg.sender == dsSwapContract);
     }
 
     // **** ADD LIQUIDITY ****
@@ -193,7 +195,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
@@ -205,7 +207,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, applyFee());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
@@ -218,7 +220,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path, applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -231,7 +233,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, applyFee());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
@@ -245,7 +247,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
@@ -260,7 +262,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, applyFee());
         require(amounts[0] <= msg.value, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -281,10 +283,10 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
     }
 
     function getAmountsOut(uint amountIn, address[] memory path) public view override returns (uint[] memory amounts) {
-        return UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
+        return UniswapV2Library.getAmountsOut(factory, amountIn, path, applyFee());
     }
 
     function getAmountsIn(uint amountOut, address[] memory path) public view override returns (uint[] memory amounts) {
-        return UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
+        return UniswapV2Library.getAmountsIn(factory, amountOut, path, applyFee());
     }
 }

--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -11,6 +11,8 @@ import './interfaces/IWETH.sol';
 contract UniswapV2Router01 is IUniswapV2Router01 {
     address public immutable override factory;
     address public immutable override WETH;
+    address public dsSwapContract;
+
 
     modifier ensure(uint deadline) {
         require(deadline >= block.timestamp, 'UniswapV2Router: EXPIRED');
@@ -24,6 +26,13 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
 
     receive() external payable {
         assert(msg.sender == WETH); // only accept ETH via fallback from the WETH contract
+    }
+
+    // IMPORTANT : will not apply fee if the caller is the dsSwapContract
+    // WARNING : not applying fee also comes with disabling rounding error safeguard check as it creates an inexact amount of tokens needed for repayment
+    // maybe will be added back at later date if we decided to have a fee on DS swap
+    function feeWhitelisted()  internal view returns (bool) {
+        return msg.sender == dsSwapContract;
     }
 
     // **** ADD LIQUIDITY ****
@@ -183,7 +192,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
@@ -195,7 +204,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
@@ -208,7 +217,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path);
+        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path, feeWhitelisted());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -221,7 +230,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
@@ -235,7 +244,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
@@ -250,7 +259,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
         require(amounts[0] <= msg.value, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -271,10 +280,10 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
     }
 
     function getAmountsOut(uint amountIn, address[] memory path) public view override returns (uint[] memory amounts) {
-        return UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        return UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
     }
 
     function getAmountsIn(uint amountOut, address[] memory path) public view override returns (uint[] memory amounts) {
-        return UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        return UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
     }
 }

--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -19,9 +19,10 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         _;
     }
 
-    constructor(address _factory, address _WETH) public {
+    constructor(address _factory, address _WETH, address _dsSwapContract) public {
         factory = _factory;
         WETH = _WETH;
+        dsSwapContract = _dsSwapContract;
     }
 
     receive() external payable {

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -14,6 +14,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
 
     address public immutable override factory;
     address public immutable override WETH;
+    address public swapContract;
 
     modifier ensure(uint deadline) {
         require(deadline >= block.timestamp, 'UniswapV2Router: EXPIRED');

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -30,8 +30,10 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
     // IMPORTANT : will not apply fee if the caller is the dsSwapContract
     // WARNING : not applying fee also comes with disabling rounding error safeguard check as it creates an inexact amount of tokens needed for repayment
     // maybe will be added back at later date if we decided to have a fee on DS swap
-    function feeWhitelisted()  internal view returns (bool) {
-        return msg.sender == dsSwapContract;
+    // potential result of this is on every trade, there's a possibility that the actual repayment amount transferred is verrrry slightly less than the amount needed for repayment. 
+    // leaving the AMM with verry slightly less liquidity from before
+    function applyFee()  internal view returns (bool) {
+        return !(msg.sender == dsSwapContract);
     }
 
     receive() external payable {
@@ -237,7 +239,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         address to,
         uint deadline
     ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path, applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
@@ -251,7 +253,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         address to,
         uint deadline
     ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path, applyFee());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
@@ -267,7 +269,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path,feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path,applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -281,7 +283,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path,feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path,applyFee());
         require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
@@ -298,7 +300,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         returns (uint[] memory amounts)
     {
         require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path,feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path,applyFee());
         require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
@@ -316,7 +318,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         returns (uint[] memory amounts)
     {
         require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path,feeWhitelisted());
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path,applyFee());
         require(amounts[0] <= msg.value, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
         IWETH(WETH).deposit{value: amounts[0]}();
         assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
@@ -440,7 +442,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         override
         returns (uint[] memory amounts)
     {
-        return UniswapV2Library.getAmountsOut(factory, amountIn, path,feeWhitelisted());
+        return UniswapV2Library.getAmountsOut(factory, amountIn, path,applyFee());
     }
 
     function getAmountsIn(uint amountOut, address[] memory path)
@@ -450,6 +452,6 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         override
         returns (uint[] memory amounts)
     {
-        return UniswapV2Library.getAmountsIn(factory, amountOut, path,feeWhitelisted());
+        return UniswapV2Library.getAmountsIn(factory, amountOut, path,applyFee());
     }
 }

--- a/contracts/examples/ExampleFlashSwap.sol
+++ b/contracts/examples/ExampleFlashSwap.sol
@@ -48,7 +48,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             (uint minETH) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
             token.approve(address(exchangeV1), amountToken);
             uint amountReceived = exchangeV1.tokenToEthSwapInput(amountToken, minETH, uint(-1));
-            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountToken, path, false)[0];
+            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountToken, path, true)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough ETH back to repay our flash loan
             WETH.deposit{value: amountRequired}();
             assert(WETH.transfer(msg.sender, amountRequired)); // return WETH to V2 pair
@@ -58,7 +58,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             (uint minTokens) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
             WETH.withdraw(amountETH);
             uint amountReceived = exchangeV1.ethToTokenSwapInput{value: amountETH}(minTokens, uint(-1));
-            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountETH, path, false)[0];
+            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountETH, path, true)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough tokens back to repay our flash loan
             assert(token.transfer(msg.sender, amountRequired)); // return tokens to V2 pair
             assert(token.transfer(sender, amountReceived - amountRequired)); // keep the rest! (tokens)

--- a/contracts/examples/ExampleFlashSwap.sol
+++ b/contracts/examples/ExampleFlashSwap.sol
@@ -48,7 +48,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             (uint minETH) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
             token.approve(address(exchangeV1), amountToken);
             uint amountReceived = exchangeV1.tokenToEthSwapInput(amountToken, minETH, uint(-1));
-            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountToken, path)[0];
+            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountToken, path, false)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough ETH back to repay our flash loan
             WETH.deposit{value: amountRequired}();
             assert(WETH.transfer(msg.sender, amountRequired)); // return WETH to V2 pair
@@ -58,7 +58,7 @@ contract ExampleFlashSwap is IUniswapV2Callee {
             (uint minTokens) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
             WETH.withdraw(amountETH);
             uint amountReceived = exchangeV1.ethToTokenSwapInput{value: amountETH}(minTokens, uint(-1));
-            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountETH, path)[0];
+            uint amountRequired = UniswapV2Library.getAmountsIn(factory, amountETH, path, false)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough tokens back to repay our flash loan
             assert(token.transfer(msg.sender, amountRequired)); // return tokens to V2 pair
             assert(token.transfer(sender, amountReceived - amountRequired)); // keep the rest! (tokens)

--- a/test/ExampleSwapToPrice.spec.ts
+++ b/test/ExampleSwapToPrice.spec.ts
@@ -192,7 +192,7 @@ describe('ExampleSwapToPrice', () => {
         overrides
       )
       const receipt = await tx.wait()
-      expect(receipt.gasUsed).to.eq('115129')
+      expect(receipt.gasUsed).to.eq('116067')
     }).retries(2) // gas test is inconsistent
   })
 })

--- a/test/UniswapV2Router01.spec.ts
+++ b/test/UniswapV2Router01.spec.ts
@@ -368,8 +368,8 @@ describe('UniswapV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.UniswapV2Router01]: 101876,
-              [RouterVersion.UniswapV2Router02]: 101898
+              [RouterVersion.UniswapV2Router01]: 102792,
+              [RouterVersion.UniswapV2Router02]: 102836
             }[routerVersion as RouterVersion]
           )
         }).retries(3)
@@ -517,8 +517,8 @@ describe('UniswapV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.UniswapV2Router01]: 138770,
-              [RouterVersion.UniswapV2Router02]: 138770
+              [RouterVersion.UniswapV2Router01]: 139686,
+              [RouterVersion.UniswapV2Router02]: 139708
             }[routerVersion as RouterVersion]
           )
         }).retries(3)

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -45,7 +45,7 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const WETHPartner = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
 
   // placeholder for swap contract address
-  const swapContract = '0x0000000000000000000000000000000000000000'
+  const swapContract = '0x00000000000000000000000000dead0000000000'
 
   // deploy V1
   const factoryV1 = await deployContract(wallet, UniswapV1Factory, [])

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -44,6 +44,9 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const WETH = await deployContract(wallet, WETH9)
   const WETHPartner = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
 
+  // placeholder for swap contract address
+  const swapContract = '0x0000000000000000000000000000000000000000'
+
   // deploy V1
   const factoryV1 = await deployContract(wallet, UniswapV1Factory, [])
   await factoryV1.initializeFactory((await deployContract(wallet, UniswapV1Exchange, [])).address)
@@ -52,8 +55,8 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const factoryV2 = await deployContract(wallet, UniswapV2Factory, [wallet.address])
 
   // deploy routers
-  const router01 = await deployContract(wallet, UniswapV2Router01, [factoryV2.address, WETH.address], overrides)
-  const router02 = await deployContract(wallet, UniswapV2Router02, [factoryV2.address, WETH.address], overrides)
+  const router01 = await deployContract(wallet, UniswapV2Router01, [factoryV2.address, WETH.address, swapContract], overrides)
+  const router02 = await deployContract(wallet, UniswapV2Router02, [factoryV2.address, WETH.address, swapContract], overrides)
 
   // event emitter for testing
   const routerEventEmitter = await deployContract(wallet, RouterEventEmitter, [])


### PR DESCRIPTION
# Changes
- added fee whitelisting for DS swap contract
- adjusted some test

# Important Note
Currently, there's a possibility of verrrry slight flash swap underpayment on every trade when the fee isn't applied(e.g DS-CT flash swap). This is potentially caused by a rounding error when calculating the amount of token that goes in and out. Reason for disabling mainly because we don't currently planning to take any fee from user swapping DS(at least not yet) and without a fee that can be used for repayment buffer, we need to rely on **_exactly or less_** of the amount needed to repay.
The exact function can be seen here :

- [getAmountIn](https://github.com/Cork-Technology/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L53)
- [getAmountOut](https://github.com/Cork-Technology/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L43)